### PR TITLE
Changed line dash phase to HPDF_REAL

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -1151,7 +1151,7 @@ HPDF_EXPORT(HPDF_STATUS)
 HPDF_Page_SetDash  (HPDF_Page           page,
                     const HPDF_REAL    *dash_ptn,
                     HPDF_UINT           num_param,
-                    HPDF_UINT           phase);
+                    HPDF_REAL           phase);
 
 
 

--- a/include/hpdf_types.h
+++ b/include/hpdf_types.h
@@ -207,9 +207,9 @@ typedef struct _HPDF_TextWidth {
 /*------ dash mode ----------------------------------------------------------*/
 
 typedef struct _HPDF_DashMode {
-    HPDF_UINT16  ptn[8];
+    HPDF_REAL    ptn[8];
     HPDF_UINT    num_ptn;
-    HPDF_UINT    phase;
+    HPDF_REAL    phase;
 } HPDF_DashMode;
 
 

--- a/src/hpdf_gstate.c
+++ b/src/hpdf_gstate.c
@@ -70,7 +70,7 @@ HPDF_GState_New  (HPDF_MMgr    mmgr,
         HPDF_TransMatrix DEF_MATRIX = {1, 0, 0, 1, 0, 0};
         HPDF_RGBColor DEF_RGB_COLOR = {0, 0, 0};
         HPDF_CMYKColor DEF_CMYK_COLOR = {0, 0, 0, 0};
-        HPDF_DashMode DEF_DASH_MODE = {{0, 0, 0, 0, 0, 0, 0, 0}, 0, 0};
+        HPDF_DashMode DEF_DASH_MODE = {{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, 0, 0.0f};
 
         gstate->trans_matrix = DEF_MATRIX;
         gstate->line_width = HPDF_DEF_LINEWIDTH;

--- a/src/hpdf_page_operator.c
+++ b/src/hpdf_page_operator.c
@@ -21,7 +21,7 @@
 #include "hpdf.h"
 
 static const HPDF_Point INIT_POS = {0, 0};
-static const HPDF_DashMode INIT_MODE = {{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, 0, 0};
+static const HPDF_DashMode INIT_MODE = {{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, 0, 0.0f};
 
 
 static HPDF_STATUS
@@ -177,7 +177,7 @@ HPDF_EXPORT(HPDF_STATUS)
 HPDF_Page_SetDash  (HPDF_Page           page,
                     const HPDF_REAL    *dash_ptn,
                     HPDF_UINT           num_param,
-                    HPDF_UINT           phase)
+                    HPDF_REAL           phase)
 {
     HPDF_STATUS ret = HPDF_Page_CheckState (page, HPDF_GMODE_PAGE_DESCRIPTION |
                     HPDF_GMODE_TEXT_OBJECT);
@@ -192,10 +192,6 @@ HPDF_Page_SetDash  (HPDF_Page           page,
 
     if (ret != HPDF_OK)
         return ret;
-
-    if (num_param != 1 && (num_param / 2) * 2 != num_param)
-        return HPDF_RaiseError (page->error, HPDF_PAGE_INVALID_PARAM_COUNT,
-                num_param);
 
     if (num_param == 0 && phase > 0)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE,
@@ -220,7 +216,7 @@ HPDF_Page_SetDash  (HPDF_Page           page,
     *pbuf++ = ']';
     *pbuf++ = ' ';
 
-    pbuf = HPDF_IToA (pbuf, phase, eptr);
+    pbuf = HPDF_FToA (pbuf, phase, eptr);
     HPDF_StrCpy (pbuf, " d\012", eptr);
 
     attr = (HPDF_PageAttr)page->attr;

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -890,7 +890,7 @@ HPDF_Page_GetMiterLimit  (HPDF_Page   page)
 HPDF_EXPORT(HPDF_DashMode)
 HPDF_Page_GetDash  (HPDF_Page   page)
 {
-    HPDF_DashMode mode = {{0, 0, 0, 0, 0, 0, 0, 0}, 0, 0};
+    HPDF_DashMode mode = {{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, 0, 0.0f};
 
     HPDF_PTRACE((" HPDF_Page_GetDash\n"));
 


### PR DESCRIPTION
Changed dash phase to HPDF_REAL.
Removed if-statement which checked if the number of dash pattern array elements is even, because I could not find a reason for this check in the PDF reference.
