### PR TITLE
Parsing of AFM files allows wrong count of C

### DIFF
--- a/src/hpdf_fontdef_type1.c
+++ b/src/hpdf_fontdef_type1.c
@@ -251,6 +251,10 @@ LoadAfm (HPDF_FontDef  fontdef,
 
         /* C default character code. */
         s = GetKeyword (buf, buf2, HPDF_LIMIT_MAX_NAME_LEN + 1);
+        if (HPDF_StrCmp (buf2, "EndCharMetrics") == 0) {
+            attr->widths_count = i;
+            break;
+        } else
         if (HPDF_StrCmp (buf2, "CX") == 0) {
             /* not suppoted yet. */
             return HPDF_SetError (fontdef->error,


### PR DESCRIPTION
When parsing a corrupt AFM file the libharu will not rise an error when
there are not enough / too much C-commands.

Fixes #15
