### PR TITLE
Added methods HPDF_SetTextPlacementAccuracy and HPDF_SetWriteFontWidths

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -1595,6 +1595,14 @@ HPDF_Page_TextField  (HPDF_Page            page,
                       HPDF_Font            font,
                       HPDF_REAL            font_size,
                       HPDF_Color           color);
+
+HPDF_EXPORT(HPDF_STATUS)
+HPDF_SetTextPlacementAccuracy (HPDF_Doc  pdf,
+                               HPDF_UINT decimal_places);
+
+HPDF_EXPORT(HPDF_STATUS)
+HPDF_SetWriteFontWidths (HPDF_Doc  pdf,
+                         HPDF_BOOL write_font_widths);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/hpdf_consts.h
+++ b/include/hpdf_consts.h
@@ -68,6 +68,9 @@
 #define HPDF_DEF_PAGE_WIDTH         595.276F
 #define HPDF_DEF_PAGE_HEIGHT        841.89F
 
+/* default decimal places for text placement accuracy */
+#define HPDF_DEF_TEXT_PLACEMENT_ACCURACY  5
+
 /*---------------------------------------------------------------------------*/
 /*----- compression mode ----------------------------------------------------*/
 

--- a/include/hpdf_doc.h
+++ b/include/hpdf_doc.h
@@ -63,6 +63,12 @@ typedef struct _HPDF_Doc_Rec {
     /* default compression mode */
     HPDF_BOOL         compression_mode;
 
+    /* decimal places for text placement accuracy */
+    HPDF_UINT         text_placement_accuracy;
+
+    /* states if font widths will be written for fonts without font data */
+    HPDF_BOOL         write_font_widths;
+
     HPDF_BOOL         encrypt_on;
     HPDF_EncryptDict  encrypt_dict;
 

--- a/include/hpdf_fontdef.h
+++ b/include/hpdf_fontdef.h
@@ -151,6 +151,7 @@ typedef struct _HPDF_Type1FontDefAttrRec {
     HPDF_UINT       length3;
     HPDF_BOOL       is_base14font;
     HPDF_BOOL       is_fixed_pitch;
+    HPDF_BOOL       write_widths;
 
     HPDF_Stream     font_data;
 } HPDF_Type1FontDefAttr_Rec;

--- a/include/hpdf_pages.h
+++ b/include/hpdf_pages.h
@@ -65,6 +65,7 @@ typedef struct _HPDF_PageAttr_Rec {
     HPDF_Stream        stream;
     HPDF_Xref          xref;
     HPDF_UINT          compression_mode;
+    HPDF_UINT          text_placement_accuracy;
 	HPDF_PDFVer       *ver; 
 } HPDF_PageAttr_Rec;
 

--- a/include/hpdf_utils.h
+++ b/include/hpdf_utils.h
@@ -25,6 +25,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
+/* can be used for rounding to 0-5 decimal places */
+static const int HPDF_DECIMAL_ROUND_COEFFICIENT[] = {1, 10, 100, 1000, 10000, 100000};
+
 HPDF_INT
 HPDF_AToI  (const char*  s);
 
@@ -50,6 +53,11 @@ HPDF_FToA  (char  *s,
             HPDF_REAL  val,
             char  *eptr);
 
+char*
+HPDF_FToA2  (char       *s,
+             HPDF_REAL   val,
+             char       *eptr,
+             HPDF_UINT   decimal_places);
 
 HPDF_BYTE*
 HPDF_MemCpy  (HPDF_BYTE*        out,

--- a/src/hpdf_font_type1.c
+++ b/src/hpdf_font_type1.c
@@ -349,7 +349,7 @@ Type1Font_OnWrite  (HPDF_Dict    obj,
     HPDF_PTRACE ((" HPDF_Font_Type1Font_OnWrite\n"));
 
     /* if font is base14-font these entries is not required */
-    if (!fontdef_attr->is_base14font || encoder_attr->has_differences) {
+    if ( ( fontdef_attr->write_widths || fontdef_attr->font_data ) && ( !fontdef_attr->is_base14font || encoder_attr->has_differences ) ) {
         char *pbuf;
 
         pbuf = (char *)HPDF_StrCpy (buf, "/FirstChar ", eptr);

--- a/src/hpdf_page_operator.c
+++ b/src/hpdf_page_operator.c
@@ -1270,13 +1270,17 @@ HPDF_Page_MoveTextPos  (HPDF_Page  page,
 
     HPDF_MemSet (buf, 0, HPDF_TMP_BUF_SIZ);
 
-    pbuf = HPDF_FToA (pbuf, x, eptr);
+    pbuf = HPDF_FToA2 (pbuf, x, eptr, attr->text_placement_accuracy);
     *pbuf++ = ' ';
-    pbuf = HPDF_FToA (pbuf, y, eptr);
+    pbuf = HPDF_FToA2 (pbuf, y, eptr, attr->text_placement_accuracy);
     HPDF_StrCpy (pbuf, " Td\012", eptr);
 
     if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
+
+    float round = HPDF_DECIMAL_ROUND_COEFFICIENT[attr->text_placement_accuracy];
+    x = roundf(x * round) / round;
+    y = roundf(y * round) / round;
 
     attr->text_matrix.x += x * attr->text_matrix.a + y * attr->text_matrix.c;
     attr->text_matrix.y += y * attr->text_matrix.d + x * attr->text_matrix.b;
@@ -1307,13 +1311,17 @@ HPDF_Page_MoveTextPos2  (HPDF_Page  page,
 
     HPDF_MemSet (buf, 0, HPDF_TMP_BUF_SIZ);
 
-    pbuf = HPDF_FToA (pbuf, x, eptr);
+    pbuf = HPDF_FToA2 (pbuf, x, eptr, attr->text_placement_accuracy);
     *pbuf++ = ' ';
-    pbuf = HPDF_FToA (pbuf, y, eptr);
+    pbuf = HPDF_FToA2 (pbuf, y, eptr, attr->text_placement_accuracy);
     HPDF_StrCpy (pbuf, " TD\012", eptr);
 
     if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
+
+    float round = HPDF_DECIMAL_ROUND_COEFFICIENT[attr->text_placement_accuracy];
+    x = roundf(x * round) / round;
+    y = roundf(y * round) / round;
 
     attr->text_matrix.x += x * attr->text_matrix.a + y * attr->text_matrix.c;
     attr->text_matrix.y += y * attr->text_matrix.d + x * attr->text_matrix.b;

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -1981,3 +1981,14 @@ HPDF_Page_SetFilter  (HPDF_Page    page,
     attr->contents->filter = filter;
 }
 
+void
+HPDF_Page_SetTextPlacementAccuracy  (HPDF_Page    page,
+                                     HPDF_UINT decimal_places)
+{
+    HPDF_PageAttr attr;
+
+    HPDF_PTRACE((" HPDF_Page_SetTextPlacementAccuracy\n"));
+
+    attr = (HPDF_PageAttr)page->attr;
+    attr->text_placement_accuracy = decimal_places;
+}

--- a/src/hpdf_utils.c
+++ b/src/hpdf_utils.c
@@ -182,6 +182,16 @@ HPDF_FToA  (char       *s,
             HPDF_REAL   val,
             char       *eptr)
 {
+    return HPDF_FToA2 (s, val, eptr, HPDF_DEF_TEXT_PLACEMENT_ACCURACY);
+}
+
+
+char*
+HPDF_FToA2  (char       *s,
+             HPDF_REAL   val,
+             char       *eptr,
+             HPDF_UINT   decimal_places)
+{
     HPDF_INT32 int_val;
     HPDF_INT32 fpart_val;
     char buf[HPDF_REAL_LEN + 1];
@@ -204,11 +214,12 @@ HPDF_FToA  (char       *s,
     }
 
     /* separate an integer part and a decimal part. */
-    int_val = (HPDF_INT32)(val + 0.000005);
-    fpart_val = (HPDF_INT32)((HPDF_REAL)(val - int_val + 0.000005) * 100000);
+    HPDF_REAL round = 0.5f / HPDF_DECIMAL_ROUND_COEFFICIENT[decimal_places];
+    int_val = (HPDF_INT32)(val + round);
+    fpart_val = (HPDF_INT32)((HPDF_REAL)(val - int_val + round) * HPDF_DECIMAL_ROUND_COEFFICIENT[decimal_places]);
 
     /* process decimal part */
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < decimal_places; i++) {
         *t = (char)((char)(fpart_val % 10) + '0');
         fpart_val /= 10;
         t--;

--- a/win32/mingw/libhpdf.def
+++ b/win32/mingw/libhpdf.def
@@ -188,6 +188,8 @@ EXPORTS
  HPDF_SaveToFile@8                   = HPDF_SaveToFile
  HPDF_SaveToStream@4                 = HPDF_SaveToStream
  HPDF_SetCompressionMode@8           = HPDF_SetCompressionMode
+ HPDF_SetTextPlacementAccuracy@8     = HPDF_SetTextPlacementAccuracy
+ HPDF_SetWriteFontWidths@8           = HPDF_SetWriteFontWidths
  HPDF_SetCurrentEncoder@8            = HPDF_SetCurrentEncoder
  HPDF_SetEncryptionMode@12           = HPDF_SetEncryptionMode
  HPDF_SetErrorHandler@8              = HPDF_SetErrorHandler

--- a/win32/mingw/libhpdf_cdecl.def
+++ b/win32/mingw/libhpdf_cdecl.def
@@ -187,6 +187,8 @@ EXPORTS
     HPDF_SaveToFile
     HPDF_SaveToStream
     HPDF_SetCompressionMode
+    HPDF_SetTextPlacementAccuracy
+    HPDF_SetWriteFontWidths
     HPDF_SetCurrentEncoder
     HPDF_SetEncryptionMode
     HPDF_SetErrorHandler

--- a/win32/msvc/libhpdf.def
+++ b/win32/msvc/libhpdf.def
@@ -199,6 +199,8 @@ EXPORTS
     HPDF_SaveToFile
     HPDF_SaveToStream
     HPDF_SetCompressionMode
+    HPDF_SetTextPlacementAccuracy
+    HPDF_SetWriteFontWidths
     HPDF_SetCurrentEncoder
     HPDF_SetEncryptionMode
     HPDF_SetErrorHandler


### PR DESCRIPTION
HPDF_SetTextPlacementAccuracy can be used to set how many decimal places should be used when positioning text.
HPDF_SetWriteFontWidths can be used to set if width entries of fonts which are not embedded should be written.