### PR TITLE
Added support for radio button fields

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -7,4 +7,4 @@ include_HEADERS =   hpdf.h hpdf_annotation.h hpdf_encoder.h hpdf_ext_gstate.h \
 					hpdf_encrypt.h hpdf_font.h hpdf_info.h hpdf_outline.h hpdf_types.h \
 					hpdf_doc.h hpdf_error.h hpdf_gstate.h hpdf_list.h hpdf_page_label.h \
 					hpdf_u3d.h hpdf_config.h hpdf_version.h hpdf_namedict.h hpdf_pdfa.h \
-					hpdf_3dmeasure.h hpdf_exdata.h hpdf_structure_element.h
+					hpdf_3dmeasure.h hpdf_exdata.h hpdf_structure_element.h hpdf_field.h

--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -1719,6 +1719,11 @@ HPDF_EXPORT(HPDF_StructureElement)
 HPDF_CreateForm  (HPDF_Doc              pdf,
                   HPDF_StructureElement parent);
 
+HPDF_EXPORT(HPDF_RadioButtonField)
+HPDF_CreateRadioButtonField  (HPDF_Doc    pdf,
+                              const char *name,
+                              HPDF_UINT   flag);
+
 /*--- Compatibility ------------------------------------------------------*/
 
 /* BX --not implemented yet */
@@ -1813,7 +1818,9 @@ HPDF_Page_TextField  (HPDF_Page            page,
                       HPDF_REAL            right,
                       HPDF_REAL            bottom,
                       const char          *name,
-                      const char          *text,
+                      const char          *value,
+                      HPDF_Encoder         encoder,
+                      const char          *encoded_text,
                       HPDF_UINT            flag,
                       HPDF_BOOL            print,
                       HPDF_UINT            max_len,
@@ -1846,6 +1853,21 @@ HPDF_Page_CheckboxField  (HPDF_Page      page,
                           HPDF_INT       rotation,
                           HPDF_Color     color,
                           HPDF_BOOL      checked);
+
+HPDF_EXPORT(HPDF_STATUS)
+HPDF_Page_RadioButtonField  (HPDF_Page              page,
+                             HPDF_Doc               pdf,
+                             HPDF_RadioButtonField  radio_field,
+                             HPDF_REAL              left,
+                             HPDF_REAL              top,
+                             HPDF_REAL              right,
+                             HPDF_REAL              bottom,
+                             const char            *value,
+                             HPDF_Encoder           encoder,
+                             HPDF_BOOL              print,
+                             HPDF_INT               rotation,
+                             HPDF_Color             color,
+                             HPDF_BOOL              selected);
 
 HPDF_EXPORT(HPDF_STATUS)
 HPDF_SetTextPlacementAccuracy (HPDF_Doc  pdf,

--- a/include/hpdf_consts.h
+++ b/include/hpdf_consts.h
@@ -564,11 +564,15 @@
 #define HPDF_FIELD_NOEXPORT            4           /*    3    */
 #define HPDF_FIELD_MULTILINE           4096        /*    13   */
 #define HPDF_FIELD_PASSWORD            8192        /*    14   */
+#define HPDF_FIELD_NOTOGGLETOOFF       16384       /*    15   */
+#define HPDF_FIELD_RADIO               32768       /*    16   */
+#define HPDF_FIELD_PUSHBUTTON          65536       /*    17   */
 #define HPDF_FIELD_FILESELECT          1048576     /*    21   */
 #define HPDF_FIELD_DONOTSPELLCHECK     4194304     /*    23   */
 #define HPDF_FIELD_DONOTSCROLL         8388608     /*    24   */
 #define HPDF_FIELD_COMB                16777216    /*    25   */
 #define HPDF_FIELD_RICHTEXT            33554432    /*    26   */
+#define HPDF_FIELD_RADIOSINUNISON      33554432    /*    26   */
 
 
 /*----------------------------------------------------------------------------*/

--- a/include/hpdf_field.h
+++ b/include/hpdf_field.h
@@ -1,0 +1,53 @@
+/*
+ * << Haru Free PDF Library >> -- hpdf_field.h
+ *
+ * URL: http://libharu.org
+ *
+ * Copyright (c) 1999-2006 Takeshi Kanno <takeshi_kanno@est.hi-ho.ne.jp>
+ * Copyright (c) 2007-2009 Antony Dovgal <tony@daylessday.org>
+ *
+ * Permission to use, copy, modify, distribute and sell this software
+ * and its documentation for any purpose is hereby granted without fee,
+ * provided that the above copyright notice appear in all copies and
+ * that both that copyright notice and this permission notice appear
+ * in supporting documentation.
+ * It is provided "as is" without express or implied warranty.
+ *
+ */
+
+#ifndef _HPDF_FIELD_H
+#define _HPDF_FIELD_H
+
+#include "hpdf_objects.h"
+#include "hpdf_doc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*----------------------------------------------------------------------------*/
+/*------ HPDF_RadioButtonField ----------------------------------------------*/
+
+HPDF_RadioButtonField
+HPDF_RadioButtonField_New  (HPDF_Doc    pdf,
+                            const char *name,
+                            HPDF_UINT   flag);
+
+HPDF_STATUS
+HPDF_RadioButtonField_AddChild  (HPDF_RadioButtonField fld,
+                                 HPDF_Dict             child);
+
+HPDF_INT
+HPDF_RadioButtonField_AddOpt  (HPDF_RadioButtonField  fld,
+                               const char            *value,
+                               HPDF_Encoder           encoder);
+
+HPDF_STATUS
+HPDF_RadioButtonField_SetSelected  (HPDF_RadioButtonField  fld,
+                                    const char            *value);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* _HPDF_FIELD_H */

--- a/include/hpdf_objects.h
+++ b/include/hpdf_objects.h
@@ -606,6 +606,7 @@ typedef HPDF_Dict  HPDF_StructureElement;
 typedef HPDF_Dict  HPDF_StructTreeRoot;
 typedef HPDF_Dict  HPDF_Artifact;
 typedef HPDF_Dict  HPDF_MarkedContent;
+typedef HPDF_Dict  HPDF_RadioButtonField;
 
 #ifdef __cplusplus
 }

--- a/include/hpdf_pages.h
+++ b/include/hpdf_pages.h
@@ -85,6 +85,10 @@ HPDF_Page
 HPDF_Page_New  (HPDF_MMgr   mmgr,
                 HPDF_Xref   xref);
 
+HPDF_Page
+HPDF_Page_New_Fake (HPDF_MMgr   mmgr,
+                    HPDF_Xref   xref,
+                    HPDF_Dict   contents);
 
 void*
 HPDF_Page_GetInheritableItem  (HPDF_Page      page,

--- a/script/Makefile.mingw64_cross
+++ b/script/Makefile.mingw64_cross
@@ -86,6 +86,7 @@ OBJS = \
 	src/hpdf_namedict.o \
 	src/hpdf_u3d.o \
 	src/hpdf_structure_element.o \
+	src/hpdf_field.o \
 
 PROGRAMS = \
 	demo/encoding_list.exe \

--- a/script/Makefile.mingw64_dll_cross
+++ b/script/Makefile.mingw64_dll_cross
@@ -86,6 +86,7 @@ OBJS = \
 	src/hpdf_exdata.o \
 	src/hpdf_u3d.o \
 	src/hpdf_structure_element.o \
+	src/hpdf_field.o \
 
 PROGRAMS = \
 	demo/encoding_list.exe \

--- a/script/Makefile.mingw_cross
+++ b/script/Makefile.mingw_cross
@@ -86,6 +86,7 @@ OBJS = \
 	src/hpdf_namedict.o \
 	src/hpdf_u3d.o \
 	src/hpdf_structure_element.o \
+	src/hpdf_field.o \
 
 PROGRAMS = \
 	demo/encoding_list.exe \

--- a/script/Makefile.mingw_dll_cross
+++ b/script/Makefile.mingw_dll_cross
@@ -86,6 +86,7 @@ OBJS = \
 	src/hpdf_exdata.o \
 	src/hpdf_u3d.o \
 	src/hpdf_structure_element.o \
+	src/hpdf_field.o \
 
 PROGRAMS = \
 	demo/encoding_list.exe \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(
 	hpdf_exdata.c
 	hpdf_encoder_utf.c
 	hpdf_structure_element.c
+	hpdf_field.c
 )
 
 # =======================================================================

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,7 @@ libhpdf_la_SOURCES =	hpdf_annotation.c hpdf_array.c hpdf_binary.c hpdf_boolean.c
 						hpdf_namedict.c hpdf_null.c hpdf_number.c hpdf_objects.c hpdf_outline.c \
 						hpdf_page_label.c hpdf_page_operator.c hpdf_pages.c hpdf_real.c \
 						hpdf_streams.c hpdf_string.c hpdf_u3d.c hpdf_utils.c hpdf_xref.c hpdf_pdfa.c \
-						hpdf_3dmeasure.c hpdf_exdata.c hpdf_encoder_utf.c t4.h hpdf_structure_element.c
+						hpdf_3dmeasure.c hpdf_exdata.c hpdf_encoder_utf.c t4.h hpdf_structure_element.c hpdf_field.c
 
 INCLUDES = -I$(top_srcdir)/include 
 libhpdf_la_LIBADD = @LTLIBOBJS@

--- a/src/hpdf_catalog.c
+++ b/src/hpdf_catalog.c
@@ -512,8 +512,6 @@ HPDF_Catalog_GetAcroForm (HPDF_Catalog catalog)
         ret += HPDF_Dict_Add (form_dict, "Fields", HPDF_Array_New (form_dict->mmgr));
         ret += HPDF_Dict_Add (catalog, "AcroForm", form_dict);
 
-        ret += HPDF_Dict_AddBoolean (form_dict, "NeedAppearances", HPDF_TRUE);
-
         HPDF_Dict dr = HPDF_Dict_New (catalog->mmgr);
         if(!dr)
             return NULL;

--- a/src/hpdf_doc.c
+++ b/src/hpdf_doc.c
@@ -24,6 +24,7 @@
 #include "hpdf_info.h"
 #include "hpdf_page_label.h"
 #include "hpdf_structure_element.h"
+#include "hpdf_field.h"
 #include "hpdf.h"
 #include <string.h>
 
@@ -2977,4 +2978,12 @@ HPDF_CreateForm  (HPDF_Doc              pdf,
                   HPDF_StructureElement parent)
 {
     return HPDF_CreateStructureElement(pdf, HPDF_STRUCTURE_TYPE_FORM, parent);
+}
+
+HPDF_EXPORT(HPDF_RadioButtonField)
+HPDF_CreateRadioButtonField  (HPDF_Doc    pdf,
+                              const char *name,
+                              HPDF_UINT   flag)
+{
+    return HPDF_RadioButtonField_New(pdf, name, flag);
 }

--- a/src/hpdf_field.c
+++ b/src/hpdf_field.c
@@ -1,0 +1,141 @@
+/*
+ * << Haru Free PDF Library >> -- hpdf_field.c
+ *
+ * URL: http://libharu.org
+ *
+ * Copyright (c) 1999-2006 Takeshi Kanno <takeshi_kanno@est.hi-ho.ne.jp>
+ * Copyright (c) 2007-2009 Antony Dovgal <tony@daylessday.org>
+ *
+ * Permission to use, copy, modify, distribute and sell this software
+ * and its documentation for any purpose is hereby granted without fee,
+ * provided that the above copyright notice appear in all copies and
+ * that both that copyright notice and this permission notice appear
+ * in supporting documentation.
+ * It is provided "as is" without express or implied warranty.
+ *
+ */
+
+#include "hpdf_utils.h"
+#include "hpdf_field.h"
+#include "hpdf.h"
+
+HPDF_RadioButtonField
+HPDF_RadioButtonField_New  (HPDF_Doc    pdf,
+                            const char *name,
+                            HPDF_UINT   flag)
+{
+    HPDF_RadioButtonField fld;
+
+    HPDF_PTRACE((" HPDF_RadioButtonField_New\n"));
+
+    fld = HPDF_Dict_New (pdf->mmgr);
+    if (!fld)
+        return NULL;
+
+    if (HPDF_Xref_Add (pdf->xref, fld) != HPDF_OK)
+        return NULL;
+
+    if (HPDF_Dict_AddName (fld, "FT", "Btn") != HPDF_OK)
+        return NULL;
+
+    HPDF_String fieldName = HPDF_String_New (pdf->mmgr, name, NULL);
+    if (!fieldName)
+        return NULL;
+    if (HPDF_Dict_Add (fld, "T", fieldName) != HPDF_OK)
+        return NULL;
+
+    // ensure HPDF_FIELD_RADIO flag is set
+    flag |= HPDF_FIELD_RADIO;
+    // ensure that HPDF_PUSHBUTTON flag is not set
+    flag &= ~HPDF_FIELD_PUSHBUTTON;
+    if (HPDF_Dict_AddNumber (fld, "Ff", flag) != HPDF_OK)
+        return NULL;
+
+    if (HPDF_Catalog_AddInteractiveField (pdf->catalog, fld) != HPDF_OK)
+        return NULL;
+
+    return fld;
+}
+
+HPDF_STATUS
+HPDF_RadioButtonField_AddChild  (HPDF_RadioButtonField fld,
+                                 HPDF_Dict             child)
+{
+    HPDF_Array children;
+    HPDF_STATUS ret;
+
+    HPDF_PTRACE((" HPDF_RadioButtonField_AddChild\n"));
+
+    if ((ret = HPDF_Dict_Add (child, "Parent", fld)) != HPDF_OK)
+        return ret;
+
+    children = (HPDF_Array)HPDF_Dict_GetItem (fld, "Kids", HPDF_OCLASS_ARRAY);
+    if (!children) {
+        children = HPDF_Array_New (fld->mmgr);
+        if (!children)
+            return HPDF_Error_GetCode (fld->error);
+
+        if ((ret = HPDF_Dict_Add (fld, "Kids", children)) != HPDF_OK)
+            return ret;
+    }
+
+    return HPDF_Array_Add (children, child);
+}
+
+HPDF_INT
+HPDF_RadioButtonField_AddOpt  (HPDF_RadioButtonField  fld,
+                               const char            *value,
+                               HPDF_Encoder           encoder)
+{
+    HPDF_Array opt;
+
+    HPDF_PTRACE((" HPDF_RadioButtonField_AddOpt\n"));
+
+    opt = (HPDF_Array)HPDF_Dict_GetItem (fld, "Opt", HPDF_OCLASS_ARRAY);
+    if (!opt) {
+        opt = HPDF_Array_New (fld->mmgr);
+        if (!opt)
+            return -1;
+
+        if (HPDF_Dict_Add (fld, "Opt", opt) != HPDF_OK)
+            return -1;
+    }
+
+    HPDF_Number flag = (HPDF_Number)HPDF_Dict_GetItem (fld, "Ff", HPDF_OCLASS_NUMBER);
+    if (!flag) {
+        HPDF_SetError (fld->error, HPDF_DICT_ITEM_NOT_FOUND, 0);
+        return -1;
+    }
+
+    HPDF_String s = HPDF_String_New (fld->mmgr, value, encoder);
+    if (!s)
+        return -1;
+
+    if (HPDF_Array_Add (opt, s) != HPDF_OK)
+        return -1;
+
+    // if radios in unison is set, check if the value is already in the array
+    // if it is, return the index of the value in the array
+    if (flag->value & HPDF_FIELD_RADIOSINUNISON) {
+        HPDF_UINT i;
+        for (i = 0; i < opt->list->count; i++) {
+            HPDF_String s2 = HPDF_Array_GetItem(opt, i, HPDF_OCLASS_STRING);
+            if (!s2)
+                return -1;
+
+            if (HPDF_StrCmp(value, (const char *)s2->value) == 0)
+                return i;
+        }
+    }
+
+    return HPDF_Array_Items (opt) - 1;
+}
+
+HPDF_STATUS
+HPDF_RadioButtonField_SetSelected  (HPDF_RadioButtonField  fld,
+                                    const char            *value)
+{
+    HPDF_PTRACE((" HPDF_RadioButtonField_SetSelected\n"));
+
+    return HPDF_Dict_AddName (fld, "V", value);
+}

--- a/win32/mingw/libhpdf.def
+++ b/win32/mingw/libhpdf.def
@@ -165,6 +165,7 @@ EXPORTS
  HPDF_Page_MoveTo@12                 = HPDF_Page_MoveTo
  HPDF_Page_MoveToNextLine@4          = HPDF_Page_MoveToNextLine
  HPDF_Page_New_Content_Stream@8      = HPDF_Page_New_Content_Stream
+ HPDF_Page_RadioButtonField@84       = HPDF_Page_RadioButtonField
  HPDF_Page_Rectangle@20              = HPDF_Page_Rectangle
  HPDF_Page_SetCharSpace@8            = HPDF_Page_SetCharSpace
  HPDF_Page_SetCMYKFill@20            = HPDF_Page_SetCMYKFill
@@ -198,7 +199,7 @@ EXPORTS
  HPDF_Page_ShowTextNextLineEx@16     = HPDF_Page_ShowTextNextLineEx
  HPDF_Page_SignatureField@8          = HPDF_Page_SignatureField
  HPDF_Page_Stroke@4                  = HPDF_Page_Stroke
- HPDF_Page_TextField@8               = HPDF_Page_TextField
+ HPDF_Page_TextField@104             = HPDF_Page_TextField
  HPDF_Page_TextOut@16                = HPDF_Page_TextOut
  HPDF_Page_TextRect@32               = HPDF_Page_TextRect
  HPDF_Page_TextWidth@8               = HPDF_Page_TextWidth
@@ -284,6 +285,7 @@ EXPORTS
  HPDF_CreateBibEntry@8                      = HPDF_CreateBibEntry
  HPDF_CreateCode@8                          = HPDF_CreateCode
  HPDF_CreateLink@8                          = HPDF_CreateLink
+ HPDF_CreateRadioButtonField@12             = HPDF_CreateRadioButtonField
  HPDF_CreateAnnot@8                         = HPDF_CreateAnnot
  HPDF_CreateRuby@8                          = HPDF_CreateRuby
  HPDF_CreateWarichu@8                       = HPDF_CreateWarichu


### PR DESCRIPTION
Radio button fields can be created with HPDF_CreateRadioButtonField and HPDF_Page_RadioButtonField.

NeedAppearances will no longer be set in the AcroForm dictionary. Created proper appearance streams for text form fields.